### PR TITLE
Added sorting flags to listArtifacts and listRemotePaths

### DIFF
--- a/api/queries/rdtListArtifacts.m
+++ b/api/queries/rdtListArtifacts.m
@@ -19,6 +19,11 @@ function artifacts = rdtListArtifacts(configuration, remotePath, varargin)
 % artifacts = rdtListArtifacts( ... 'pageSize', pageSize) restricts
 % the number of search results to the given pageSize.  The default is 1000.
 %
+% artifacts = rdtListArtifacts( ... 'sortField', sortField) sort search
+% results using the given artifact field name.  The default is to sort by
+% artifacts.artifactId.  If sortField is not an existing artifact field
+% name, results will be left undorted.
+%
 % Returns a struct array describing artifacts under the given
 % remotePath, or else [] if the query failed.
 %
@@ -35,6 +40,7 @@ parser.addParameter('artifactId', '', @ischar);
 parser.addParameter('version', '', @ischar);
 parser.addParameter('type', '', @ischar);
 parser.addParameter('pageSize', 1000);
+parser.addParameter('sortField', 'artifactId', @ischar);
 parser.parse(configuration, remotePath, varargin{:});
 configuration = rdtConfiguration(parser.Results.configuration);
 remotePath = parser.Results.remotePath;
@@ -42,6 +48,7 @@ artifactId = parser.Results.artifactId;
 version = parser.Results.version;
 type = parser.Results.type;
 pageSize = parser.Results.pageSize;
+sortField = parser.Results.sortField;
 
 artifacts = [];
 
@@ -69,4 +76,4 @@ for ii = 1:nArtifacts
     r.remotePath = rdtPathDotsToSlashes(r.groupId);
     artifactCell{ii} = rdtArtifact(r);
 end
-artifacts = [artifactCell{:}];
+artifacts = rdtSortStructArray([artifactCell{:}], sortField);

--- a/api/queries/rdtListLocalArtifacts.m
+++ b/api/queries/rdtListLocalArtifacts.m
@@ -16,6 +16,11 @@ function artifacts = rdtListLocalArtifacts(configuration, remotePath, varargin)
 % artifacts = rdtListLocalArtifacts( ... 'type', type) restricts
 % search results to artifacts with exactly the given type.
 %
+% artifacts = rdtListLocalArtifacts( ... 'sortField', sortField) sort search
+% results using the given artifact field name.  The default is to sort by
+% artifacts.artifactId.  If sortField is not an existing artifact field
+% name, results will be left undorted.
+%
 % Returns a struct array describing locally cached artifacts under the
 % given remotePath, or else [] if there are none.
 %
@@ -31,12 +36,14 @@ parser.addRequired('remotePath',  @(p)ischar(p) && ~isempty(p));
 parser.addParameter('artifactId', '', @ischar);
 parser.addParameter('version', '', @ischar);
 parser.addParameter('type', '', @ischar);
+parser.addParameter('sortField', 'artifactId', @ischar);
 parser.parse(configuration, remotePath, varargin{:});
 configuration = rdtConfiguration(parser.Results.configuration);
 remotePath = parser.Results.remotePath;
 artifactId = parser.Results.artifactId;
 version = parser.Results.version;
 type = parser.Results.type;
+sortField = parser.Results.sortField;
 
 artifacts = [];
 
@@ -126,7 +133,7 @@ for gg = 1:numel(groupDirectories)
         end
     end
 end
-artifacts = [artifactCell{:}];
+artifacts = rdtSortStructArray([artifactCell{:}], sortField);
 
 %% Filter out non-matching entries, and always remove "." and "..".
 function dirs = getMatchingEntries(dirs, name)

--- a/api/queries/rdtListRemotePaths.m
+++ b/api/queries/rdtListRemotePaths.m
@@ -1,4 +1,4 @@
-function [remotePaths, repositoryName] = rdtListRemotePaths(configuration)
+function [remotePaths, repositoryName] = rdtListRemotePaths(configuration, varargin)
 %% Query an Archiva Maven repository to list available paths to artifacts.
 %
 % [remotePaths, repositoryName] = rdtListRemotePaths(configuration)
@@ -6,6 +6,9 @@ function [remotePaths, repositoryName] = rdtListRemotePaths(configuration)
 % configuration.serverUrl must point to the Archiva server root.
 % configuration.repositoryName must contain the name of a repository on the
 % server.
+%
+% rdtListRemotePaths(... 'sortFlag', sortFlag) determines whether the
+% list of remote paths will be sorted.  The default is true, sorted.
 %
 % Returns a cell array string paths returned from the Archiva respository,
 % or {} if the query failed.  Also returns the name of the repository whose
@@ -17,7 +20,12 @@ function [remotePaths, repositoryName] = rdtListRemotePaths(configuration)
 %
 % Copyright (c) 2015 RemoteDataToolbox Team
 
-configuration = rdtConfiguration(configuration);
+parser = rdtInputParser();
+parser.addRequired('configuration');
+parser.addParameter('sortFlag', true, @islogical);
+parser.parse(configuration, varargin{:});
+configuration = rdtConfiguration(parser.Results.configuration);
+sortFlag = parser.Results.sortFlag;
 
 remotePaths = {};
 
@@ -35,4 +43,9 @@ nPaths = numel(response.groupIds);
 remotePaths = cell(1, nPaths);
 for ii = 1:nPaths
     remotePaths{ii} = rdtPathDotsToSlashes(response.groupIds{ii});
+end
+
+% optional sort
+if sortFlag
+    remotePaths = sort(remotePaths);
 end

--- a/api/queries/rdtSearchArtifacts.m
+++ b/api/queries/rdtSearchArtifacts.m
@@ -24,6 +24,11 @@ function artifacts = rdtSearchArtifacts(configuration, searchText, varargin)
 % artifacts = rdtSearchArtifacts( ... 'pageSize', pageSize) restricts
 % the number of search results to the given pageSize.  The default is 1000.
 %
+% artifacts = rdtSearchArtifacts( ... 'sortField', sortField) sort search
+% results using the given artifact field name.  The default is to sort by
+% artifacts.artifactId.  If sortField is not an existing artifact field
+% name, results will be left undorted.
+%
 % Returns a struct array describing artifacts that matched the given
 % searchText and other restrictions, or else [] if the query failed.
 %
@@ -41,6 +46,7 @@ parser.addParameter('artifactId', '', @ischar);
 parser.addParameter('version', '', @ischar);
 parser.addParameter('type', '', @ischar);
 parser.addParameter('pageSize', 1000);
+parser.addParameter('sortField', 'artifactId', @ischar);
 parser.parse(configuration, searchText, varargin{:});
 configuration = rdtConfiguration(parser.Results.configuration);
 searchText = parser.Results.searchText;
@@ -49,6 +55,7 @@ artifactId = parser.Results.artifactId;
 version = parser.Results.version;
 type = parser.Results.type;
 pageSize = parser.Results.pageSize;
+sortField = parser.Results.sortField;
 
 artifacts = [];
 
@@ -80,7 +87,7 @@ for ii = 1:nHits
         'version', hit.version, ...
         'pageSize', pageSize);
 end
-artifacts = [artifactCell{:}];
+artifacts = rdtSortStructArray([artifactCell{:}], sortField);
 
 if isempty(artifacts)
     return;

--- a/api/utilities/RdtClient.m
+++ b/api/utilities/RdtClient.m
@@ -81,14 +81,12 @@ classdef RdtClient < handle
             % List artifacts under a remote path.
             %   artifacts = obj.listArtifacts() % remotePath = pwrp()
             %   artifacts = obj.listArtifacts('remotePath', remotePath)
-            %   artifacts = obj.listArtifacts('sortArtifacts',true);  % Sort by  artifactID
+            %   artifacts = obj.listArtifacts('sortField', field); % default is sort by artifactId
             
             parser = rdtInputParser();
             parser.addParameter('remotePath', obj.workingRemotePath, @ischar);
-            parser.addParameter('sortArtifacts',true,@islogical);
             parser.parse(varargin{:});
-            remotePath    = parser.Results.remotePath;
-            sortArtifacts = parser.Results.sortArtifacts;
+            remotePath = parser.Results.remotePath;
             
             if isempty(remotePath)
                 % list all artifacts by iterating remote paths
@@ -110,16 +108,6 @@ classdef RdtClient < handle
                 % list under the known path
                 artifacts = rdtListArtifacts(obj.configuration, ...
                     remotePath, varargin{:});
-            end
-            
-            % Sort by artifactId
-            if sortArtifacts
-                % I wonder if there is a better way to sort?
-                tmp = squeeze(struct2cell(artifacts));
-                id = cell(1,size(tmp,2));   % First entry is artifactId
-                for ii=1:size(tmp,2), id{ii} = char(tmp(1,ii)); end
-                [~, lst] = sort(id);
-                artifacts = artifacts(lst);
             end
         end
         

--- a/api/utilities/RdtClient.m
+++ b/api/utilities/RdtClient.m
@@ -3,8 +3,8 @@ classdef RdtClient < handle
     %
     % Data slots in this object are:
     %
-    %   configuration: Holds the remote configuration 
-    %   workingRemotePath: Holds a working remote path 
+    %   configuration: Holds the remote configuration
+    %   workingRemotePath: Holds a working remote path
     %
     % The remote path simplifies calls to the plain-old-function API.
     
@@ -33,7 +33,7 @@ classdef RdtClient < handle
         end
         
         function wrp = crp(obj, varargin)
-            % Change the working remote path. 
+            % Change the working remote path.
             % This works exactly the way cd works.
             %
             %   wrp = obj.crp() just return working remote path
@@ -74,17 +74,7 @@ classdef RdtClient < handle
             % List remote paths to artifacts.
             %   remotePaths = obj.listRemotePaths() list all paths
             %   remotePaths = obj.ListRemotePaths('sortFlag',true); % Could be set to false
-            parser = rdtInputParser();
-            parser.addParameter('sortFlag',true,@islogical);
-            parser.parse(varargin{:});
-            sortFlag = parser.Results.sortFlag;
-            
-            remotePaths = rdtListRemotePaths(obj.configuration);
-            
-            if sortFlag
-                remotePaths = sort(remotePaths);
-            end
-            
+            remotePaths = rdtListRemotePaths(obj.configuration, varargin{:});
         end
         
         function artifacts = listArtifacts(obj, varargin)
@@ -154,7 +144,7 @@ classdef RdtClient < handle
         
         function [data, artifact, downloads] = readArtifact(obj, artifactId, varargin)
             % Read data for one artifact into Matlab.
-            % The artifactID 
+            % The artifactID
             %   [data, artifact] = obj.readArtifact(artifactId)
             %   ( ... 'remotePath', remotePath) remotePath instead of pwrp()
             %   ( ... 'version', version) version instead of default latest

--- a/api/utilities/RdtClient.m
+++ b/api/utilities/RdtClient.m
@@ -85,8 +85,10 @@ classdef RdtClient < handle
             
             parser = rdtInputParser();
             parser.addParameter('remotePath', obj.workingRemotePath, @ischar);
+            parser.addParameter('sortField', 'artifactId', @ischar);
             parser.parse(varargin{:});
             remotePath = parser.Results.remotePath;
+            sortField = parser.Results.sortField;
             
             if isempty(remotePath)
                 % list all artifacts by iterating remote paths
@@ -102,7 +104,7 @@ classdef RdtClient < handle
                         varargin{:}, ...
                         'remotePath', remotePaths{ii});
                 end
-                artifacts = [artifactCollection{:}];
+                artifacts = rdtSortStructArray([artifactCollection{:}], sortField);
                 
             else
                 % list under the known path

--- a/api/utilities/rdtSortStructArray.m
+++ b/api/utilities/rdtSortStructArray.m
@@ -1,0 +1,50 @@
+function [sorted, order] = rdtSortStructArray(structArray, fieldName)
+%% Sort a struct array based on the values in one field.
+%
+% sorted = rdtSortStructArray(structArray, fieldName) sorts elements
+% elements of the given structArray, based on the values of the field with
+% the given fieldName.  Values of this field must be all numeric or all
+% strings.  If the given structArray has no field with the given fieldName,
+% returns the original structArray as-is.
+%
+% [sorted, order] = rdtSortStructArray(structArray ... ) also returns
+% a set of ordered indices such that sorted = structArray(order).
+%
+% [sorted, order] = rdtSortStructArray(structArray, fieldName)
+%
+% Copyright (c) 2016 RemoteDataToolbox Team
+
+parser = rdtInputParser();
+parser.addRequired('structArray', @isstruct);
+parser.addRequired('fieldName', @ischar);
+parser.parse(structArray, fieldName);
+structArray = parser.Results.structArray;
+fieldName = parser.Results.fieldName;
+
+nElements = numel(structArray);
+sorted = structArray;
+order = 1:nElements;
+
+%% Sanity check the fieldName.
+if ~isfield(structArray, fieldName)
+    return;
+end
+
+%% Sort on the given field.
+fieldValues = {structArray.(fieldName)};
+if iscellstr(fieldValues)
+    % sort string values
+    [~, order] = sort(fieldValues);
+else
+    % treat all as numeric values
+    %   replace missing values with nan to preserve element positions
+    numericValues = nan(1, nElements);
+    for ii = 1:nElements
+        fieldValue = fieldValues{ii};
+        if ~isempty(fieldValue) && isnumeric(fieldValue)
+            numericValues(ii) = fieldValue;
+        end
+    end
+    [~, order] = sort(numericValues);
+end
+sorted = structArray(order);

--- a/test/RdtStructArrayTests.m
+++ b/test/RdtStructArrayTests.m
@@ -1,0 +1,53 @@
+classdef RdtStructArrayTests < matlab.unittest.TestCase
+    
+    properties (Constant)
+        structArray = struct( ...
+            'strings', {'zebra', 'yak', 'xylophish', 'albinoni', 'walmart', 'chess', 'frescobaldi'}, ...
+            'stringsEmpty', {'zebra', '', 'xylophish', 'albinoni', char(0, 1), '', char(1, 0)}, ...
+            'numeric', {1e6, 5, 4*pi(), -exp(3), 0, 0, 100}, ...
+            'numericEmpty', {1e6, [], 4*pi(), -exp(3), [], 0, 100});
+    end
+    
+    methods (Test)
+        
+        function tesstSortEmpty(testCase)
+            [sorted, order] = rdtSortStructArray(struct('a', {}), 'a');
+            testCase.assertEmpty(sorted);
+            testCase.assertEmpty(order);
+        end
+        
+        function tesstSortNotAfield(testCase)
+            [sorted, order] = rdtSortStructArray(testCase.structArray, 'nonononotafield');
+            testCase.assertEqual(sorted, testCase.structArray, 'AbsTol', 1e-15);
+            testCase.assertEqual(order, 1:numel(testCase.structArray));
+        end
+        
+        function testSortStrings(testCase)
+            [sorted, order] = rdtSortStructArray(testCase.structArray, 'strings');
+            testCase.assertEqual(order, [4 6 7 5 3 2 1]);
+            remade = testCase.structArray(order);
+            testCase.assertEqual(remade, sorted, 'AbsTol', 1e-15);
+        end
+        
+        function testSortNumerics(testCase)
+            [sorted, order] = rdtSortStructArray(testCase.structArray, 'numeric');
+            testCase.assertEqual(order, [4 5 6 2 3 7 1]);
+            remade = testCase.structArray(order);
+            testCase.assertEqual(remade, sorted, 'AbsTol', 1e-15);
+        end
+        
+        function testSortStringsEmptyValues(testCase)
+            [sorted, order] = rdtSortStructArray(testCase.structArray, 'stringsEmpty');
+            testCase.assertEqual(order, [2 6 5 7 4 3 1]);
+            remade = testCase.structArray(order);
+            testCase.assertEqual(remade, sorted, 'AbsTol', 1e-15);
+        end
+        
+        function testSortNumericsEmptyValues(testCase)
+            [sorted, order] = rdtSortStructArray(testCase.structArray, 'numericEmpty');
+            testCase.assertEqual(order, [4 6 3 7 1 2 5]);
+            remade = testCase.structArray(order);
+            testCase.assertEqual(remade, sorted, 'AbsTol', 1e-15);
+        end
+    end
+end


### PR DESCRIPTION
It is possible we just always sort, rather than have the sort flag set.
It is annoying that one is sortFlag and the other is sortArtifacts.  Maybe they should both
be sortFlag, but then we don't know what we are sorting on for the artifact case.
