### PR TITLE
Credentials feedback

### DIFF
--- a/api/queries/rdtPingServer.m
+++ b/api/queries/rdtPingServer.m
@@ -1,0 +1,39 @@
+function [isConnected, message] = rdtPingServer(configuration)
+%% Ping an Archiva Maven repository check if it's available.
+%
+% [isConnected, message] = rdtPingServer(configuration) requests a "ping"
+% response from an Archiva Maven repository. configuration.serverUrl must
+% point to the Archiva server root.  If configuration.password is empty,
+% makes a generic "ping" request that just checks if the server is
+% available.  Otherwise, makes and authenticating "ping" request that only
+% succeeds if the provided credentials are accepted by the server.
+%
+% Returns a logical value, true only if the server responded with a success
+% message.  Also returns a string message from the server in case of
+% success or failure.
+%
+% [isConnected, message] = rdtPingServer(configuration)
+%
+% Copyright (c) 2015 RemoteDataToolbox Team
+
+configuration = rdtConfiguration(configuration);
+
+isConnected = false;
+message = '';
+
+%% Generic or authenticated ping?
+if isempty(configuration.password)
+    pingPath = '/restServices/archivaServices/pingService/ping';
+else
+    pingPath = '/restServices/archivaServices/pingService/pingWithAuthz';
+end
+
+%% Ping the Archiva server.
+try
+    pingConfig = configuration;
+    pingConfig.acceptMediaType = 'text/plain';
+    message = rdtRequestWeb(pingConfig, pingPath);
+    isConnected = true;
+catch ex
+    message = ex.message;
+end

--- a/api/utilities/rdtCredentialsDialog.m
+++ b/api/utilities/rdtCredentialsDialog.m
@@ -24,6 +24,22 @@ parser.addRequired('configuration', @isstruct);
 parser.parse(configuration);
 configuration = parser.Results.configuration;
 
+% keep asking until cancel or successful credentials
+tempConfiguration = configuration;
+result = 'tryAgain';
+prompt = 'Remote Server Password';
+while strcmp('tryAgain', result)
+    [tempConfiguration, result] = tryCredentials(tempConfiguration, prompt);
+    prompt = 'Please Try Again';
+end
+
+% only keep configuration if credentials worked
+if strcmp('connected', result)
+    configuration = tempConfiguration;
+end
+
+%% Raise a credentials dialog and ping the server with the password.
+function [configuration, result] = tryCredentials(configuration, prompt)
 if isfield(configuration, 'username')
     usernameSuggestion = configuration.username;
 else
@@ -35,9 +51,22 @@ end
     'DefaultUserName', usernameSuggestion, ...
     'ValidatePassword', false, ...
     'CheckPasswordLength', false, ...
-    'WindowName', 'Remote Data Toolbox Password');
+    'WindowName', prompt);
 
 if ischar(password)
+    % the user pressed OK
     configuration.username = username;
     configuration.password = password;
+    
+    % ping the server
+    [isConnected, message] = rdtPingServer(configuration);
+    if isConnected
+        result = 'connected';
+    else
+        result = 'tryAgain';
+        fprintf('Credentials not accepted:\n%s\n', message);
+    end
+else
+    % the user pressed Cancel
+    result = 'canceled';
 end

--- a/test/RdtClientTests.m
+++ b/test/RdtClientTests.m
@@ -20,16 +20,8 @@ classdef RdtClientTests < matlab.unittest.TestCase
     
     methods (TestMethodSetup)
         function checkIfServerPresent(testCase)
-            exception = [];
-            try
-                pingConfig = testCase.testConfig;
-                pingConfig.acceptMediaType = 'text/plain';
-                pingPath = '/restServices/archivaServices/pingService/ping';
-                rdtRequestWeb(pingConfig, pingPath);
-            catch ex
-                exception = ex;
-            end
-            testCase.assumeEmpty(exception);
+            [isConnected, message] = rdtPingServer(testCase.testConfig);
+            testCase.assumeTrue(isConnected, message);
         end
     end
     

--- a/test/RdtLocalCacheTests.m
+++ b/test/RdtLocalCacheTests.m
@@ -20,16 +20,8 @@ classdef RdtLocalCacheTests < matlab.unittest.TestCase
     methods (TestMethodSetup)
         
         function checkIfServerPresent(testCase)
-            exception = [];
-            try
-                pingConfig = testCase.testConfig;
-                pingConfig.acceptMediaType = 'text/plain';
-                pingPath = '/restServices/archivaServices/pingService/ping';
-                rdtRequestWeb(pingConfig, pingPath);
-            catch ex
-                exception = ex;
-            end
-            testCase.assumeEmpty(exception);
+            [isConnected, message] = rdtPingServer(testCase.testConfig);
+            testCase.assumeTrue(isConnected, message);
             
             % make sure we have some things in the local cache
             testCase.listed = rdtListArtifacts(testCase.testConfig, 'test-group-1');

--- a/test/RdtPublishTests.m
+++ b/test/RdtPublishTests.m
@@ -21,16 +21,8 @@ classdef RdtPublishTests < matlab.unittest.TestCase
     methods (TestMethodSetup)
         
         function checkIfServerPresent(testCase)
-            exception = [];
-            try
-                pingConfig = testCase.testConfig;
-                pingConfig.acceptMediaType = 'text/plain';
-                pingPath = '/restServices/archivaServices/pingService/ping';
-                rdtRequestWeb(pingConfig, pingPath);
-            catch ex
-                exception = ex;
-            end
-            testCase.assumeEmpty(exception);
+            [isConnected, message] = rdtPingServer(testCase.testConfig);
+            testCase.assumeTrue(isConnected, message);
         end
     end
     

--- a/test/RdtQueryTests.m
+++ b/test/RdtQueryTests.m
@@ -23,16 +23,8 @@ classdef RdtQueryTests < matlab.unittest.TestCase
     methods (TestMethodSetup)
         
         function checkIfServerPresent(testCase)
-            exception = [];
-            try
-                pingConfig = testCase.testConfig;
-                pingConfig.acceptMediaType = 'text/plain';
-                pingPath = '/restServices/archivaServices/pingService/ping';
-                rdtRequestWeb(pingConfig, pingPath);
-            catch ex
-                exception = ex;
-            end
-            testCase.assumeEmpty(exception);
+            [isConnected, message] = rdtPingServer(testCase.testConfig);
+            testCase.assumeTrue(isConnected, message);
         end
         
     end

--- a/test/RdtReadTests.m
+++ b/test/RdtReadTests.m
@@ -19,16 +19,8 @@ classdef RdtReadTests < matlab.unittest.TestCase
     methods (TestMethodSetup)
         
         function checkIfServerPresent(testCase)
-            exception = [];
-            try
-                pingConfig = testCase.testConfig;
-                pingConfig.acceptMediaType = 'text/plain';
-                pingPath = '/restServices/archivaServices/pingService/ping';
-                rdtRequestWeb(pingConfig, pingPath);
-            catch ex
-                exception = ex;
-            end
-            testCase.assumeEmpty(exception);
+            [isConnected, message] = rdtPingServer(testCase.testConfig);
+            testCase.assumeTrue(isConnected, message);
         end
         
     end


### PR DESCRIPTION
`rdtCredentialsDialog()` and `RdtClient.credentialsDialog()` use a new "ping" utility to immediately check credentials that the user types in.

If the server accepts the "ping" request and credentials, proceeds as normal.  If the server rejects the ping, re-raises the credentials dialog and asks the user to try again.

If the user clicks "Cancel", proceeds as normal and does not alter the original credentials.
