### PR TITLE
Delete artifacts

### DIFF
--- a/api/artifacts/rdtDeleteArtifacts.m
+++ b/api/artifacts/rdtDeleteArtifacts.m
@@ -3,9 +3,10 @@ function [deleted, notDeleted] = rdtDeleteArtifacts(configuration, artifacts)
 %
 % [deleted, notDeleted] = rdtDeleteArtifacts(configuration, artifacts)
 % deletes multiple artifacts from a remote server and from the local
-% artifact cache. configuration.cacheFolder should point to the root of the local artifact
-% cache.  If configuration.cacheFolder is empty, the Gradle  default is
-% used ('~/.gradle').
+% artifact cache.  configuration.repositoryUrl must point to the repository
+% root.  configuration.cacheFolder should point to the root of the
+% local artifact cache.  If configuration.cacheFolder is empty, the Gradle
+% default is used ('~/.gradle').
 %
 % The given artifacts must be a struct array of artifact metadata, with one
 % element per artifact to delete.  rdtListArtifacts() and

--- a/api/artifacts/rdtDeleteArtifacts.m
+++ b/api/artifacts/rdtDeleteArtifacts.m
@@ -1,0 +1,85 @@
+function [deleted, notDeleted] = rdtDeleteArtifacts(configuration, artifacts)
+%% Delete multiple artifacts from a remote server and the local cache.
+%
+% [deleted, notDeleted] = rdtDeleteArtifacts(configuration, artifacts)
+% deletes multiple artifacts from a remote server and from the local
+% artifact cache. configuration.cacheFolder should point to the root of the local artifact
+% cache.  If configuration.cacheFolder is empty, the Gradle  default is
+% used ('~/.gradle').
+%
+% The given artifacts must be a struct array of artifact metadata, with one
+% element per artifact to delete.  rdtListArtifacts() and
+% rdtSearchArtifacts() return such struct arrays.
+%
+% Returns a subset of the given artifacts struct array indicating which
+% artifacts were actually deleted from the remote server.  Also returns a
+% subset indicating which artifacts were not deleted if any.
+%
+% See also rdtListArtifacts rdtSearchArtifacts rdtDeleteLocalArtifacts
+%
+% [deleted, notDeleted] = rdtDeleteArtifacts(configuration, artifacts)
+%
+% Copyright (c) 2015 RemoteDataToolbox Team
+
+parser = rdtInputParser();
+parser.addRequired('configuration');
+parser.addRequired('artifacts', @isstruct);
+parser.parse(configuration, artifacts);
+configuration = rdtConfiguration(parser.Results.configuration);
+artifacts = parser.Results.artifacts;
+
+%% Implementation note:
+% This delete operation is implemented in an Archiva-specific way.  So from
+% an implementation point of view, I would like to put this function in the
+% api/queries folder along with other functions that use the Archiva
+% RESTful API.
+%
+% But from a user point of view, it seems right to put this function here
+% in api/artifacts along with other functions related to the artifact
+% lifecycle.
+
+%% Attempt to delete each artifact, one at a time.
+nArtifacts = numel(artifacts);
+isDeleted = false(1, nArtifacts);
+for ii = 1:nArtifacts
+    % try to delete from remote server
+    isDeleted(ii) = archivaDeleteArtifact(configuration, artifacts(ii));
+    
+    % try to delete from local cache
+    foundLocally = rdtListLocalArtifacts(configuration, ...
+        artifacts(ii).remotePath, ...
+        'artifactId', artifacts(ii).artifactId, ...
+        'version', artifacts(ii).version, ...
+        'type', artifacts(ii).type);
+    if ~isempty(foundLocally)
+        rdtDeleteLocalArtifacts(configuration, foundLocally);
+    end
+end
+
+deleted = artifacts(isDeleted);
+notDeleted = artifacts(~isDeleted);
+
+% Ask Archiva to delete an artifact.
+function isDeleted = archivaDeleteArtifact(configuration, artifact)
+configuration.acceptMediaType = 'text/plain';
+resourcePath = '/restServices/archivaServices/repositoriesService/deleteArtifact';
+deleteRequest = struct( ...
+    'repositoryId', configuration.repositoryName, ...
+    'version', artifact.version, ...
+    'artifactId', artifact.artifactId, ...
+    'groupId', rdtPathSlashesToDots(artifact.remotePath), ...
+    'classifier', artifact.type, ...
+    'packaging', artifact.type);
+
+try
+    message = rdtRequestWeb(configuration, resourcePath, 'requestBody', deleteRequest);
+    isDeleted = strcmpi('true', message);
+catch ex
+    isDeleted = false;
+    message = ex.message;
+end
+
+if ~isDeleted
+    fprintf('Could not delete remote artifact <%s>:\n%s\n', artifact.url, message);
+    fprintf('Does your configuration have good credentials?\n');
+end

--- a/api/artifacts/rdtDeleteLocalArtifacts.m
+++ b/api/artifacts/rdtDeleteLocalArtifacts.m
@@ -1,0 +1,68 @@
+function [deleted, notDeleted] = rdtDeleteLocalArtifacts(configuration, artifacts)
+%% Delete multiple artifacts from the local artifact cache.
+%
+% [deleted, notDeleted] = rdtDeleteLocalArtifacts(configuration, artifacts)
+% deletes multiple artifacts from the local artifact cache.
+% configuration.cacheFolder should point to the root of the local artifact
+% cache.  If configuration.cacheFolder is empty, the Gradle  default is
+% used ('~/.gradle').
+%
+% The given artifacts must be a struct array of artifact metadata, with one
+% element per artifact to delete.  rdtListLocalArtifacts() returns such a
+% struct array.
+%
+% This function has no effect on a remote server.
+%
+% Returns a subset of the given artifacts struct array indicating which
+% artifacts were actually deleted.  Also returns a subset indicating which
+% artifacts were not deleted if any.
+%
+% See also rdtListLocalArtifacts
+%
+% [deleted, notDeleted] = rdtDeleteLocalArtifacts(configuration, artifacts)
+%
+% Copyright (c) 2015 RemoteDataToolbox Team
+
+parser = rdtInputParser();
+parser.addRequired('configuration');
+parser.addRequired('artifacts', @isstruct);
+parser.parse(configuration, artifacts);
+configuration = rdtConfiguration(parser.Results.configuration);
+artifacts = parser.Results.artifacts;
+
+%% Implementation note:
+% The configuration parameter is not currently used because we get all the
+% information we need from the artifact struct itself.  But I think we
+% should still include the configuration parameter.  That way this function
+% is consistent with the rest of the RDT API.  Also, we might want to use
+% the configuraiton later for some purpose we haven't thought of yet, and
+% it might be awkward to change this funciton's interface at that point.
+%
+% One way we might use the configuration parameter would be to sanity-check
+% that configuration.cacheFolder actually contains the given artifacts.
+
+%% Attempt to delete each artifact, one at a time.
+nArtifacts = numel(artifacts);
+isDeleted = false(1, nArtifacts);
+for ii = 1:nArtifacts
+    localPath = artifacts(ii).localPath;
+    if 2 ~= exist(localPath, 'file')
+        fprintf('Artifact file does not exist: <%s>.\n', localPath);
+        continue;
+    end
+    
+    checksumFolder = fileparts(localPath);
+    if 7 ~= exist(checksumFolder, 'dir')
+        fprintf('Artifact folder does not exist: <%s>.\n', checksumFolder);
+        continue;
+    end
+    
+    % remove the checksum folder that contains the artifact file.
+    [isDeleted(ii), message] = rmdir(checksumFolder, 's');
+    if ~isDeleted(ii)
+        fprintf('Could not delete artifact <%s>:\n%s\n', message);
+    end
+end
+
+deleted = artifacts(isDeleted);
+notDeleted = artifacts(~isDeleted);

--- a/api/artifacts/rdtDeleteLocalArtifacts.m
+++ b/api/artifacts/rdtDeleteLocalArtifacts.m
@@ -60,7 +60,7 @@ for ii = 1:nArtifacts
     % remove the checksum folder that contains the artifact file.
     [isDeleted(ii), message] = rmdir(checksumFolder, 's');
     if ~isDeleted(ii)
-        fprintf('Could not delete artifact <%s>:\n%s\n', message);
+        fprintf('Could not delete artifact <%s>:\n%s\n', checksumFolder, message);
     end
 end
 

--- a/api/artifacts/rdtDeleteLocalPaths.m
+++ b/api/artifacts/rdtDeleteLocalPaths.m
@@ -1,0 +1,48 @@
+function [deleted, notDeleted] = rdtDeleteLocalPaths(configuration, remotePath)
+%% Delete paths containing artifacts from the local artifact cache.
+%
+% [deleted, notDeleted] = rdtDeleteLocalPaths(configuration, remotePath)
+% deletes one or more directories from the local artifact cache,
+% corresponding to the given remotePath. configuration.cacheFolder should
+% point to the root of the local artifact cache.  If
+% configuration.cacheFolder is empty, the Gradle  default is used
+% ('~/.gradle').
+%
+% The given remotePath should be a string artifact path, like those
+% returned from rdtListRemotePaths().  remotePath may be a partial or
+% "super" path, which matches multiple subpaths.
+%
+% This function has no effect on a remote server.
+%
+% Returns a cell array that contains the matching paths that were actually
+% deleted. Also returns a cell array indicating matching paths that were
+% not deleted, if any.
+%
+% See also rdtListLocalArtifacts rdtDeleteLocalArtifacts
+%
+% [deleted, notDeleted] = rdtDeleteLocalPaths(configuration, remotePath)
+%
+% Copyright (c) 2015 RemoteDataToolbox Team
+
+parser = rdtInputParser();
+parser.addRequired('configuration');
+parser.addRequired('remotePath', @ischar);
+parser.parse(configuration, remotePath);
+configuration = rdtConfiguration(parser.Results.configuration);
+remotePath = parser.Results.remotePath;
+
+%% Delete all matching paths in the cache.
+[localPaths, fullPaths] = rdtListLocalPaths(configuration, ...
+    'remotePath', remotePath);
+
+nPaths = numel(fullPaths);
+isDeleted = false(1, nPaths);
+for ii = 1:nPaths
+    [isDeleted(ii), message] = rmdir(fullPaths{ii}, 's');
+    if ~isDeleted(ii)
+        fprintf('Could not delete path <%s>:\n%s\n', fullPaths{ii}, message);
+    end
+end
+
+deleted = localPaths(isDeleted);
+notDeleted = localPaths(~isDeleted);

--- a/api/artifacts/rdtDeleteRemotePaths.m
+++ b/api/artifacts/rdtDeleteRemotePaths.m
@@ -1,0 +1,82 @@
+function [deleted, notDeleted] = rdtDeleteRemotePaths(configuration, remotePath)
+%% Delete paths with artifacts from a remote server and the local cache.
+%
+% [deleted, notDeleted] = rdtDeleteRemotePaths(configuration, remotePath)
+% deletes one or more paths containing artifacts from a remote servre and
+% the the local artifact cache. configuration.repositoryUrl must point to
+% the repository root.  configuration.cacheFolder should point to the root
+% of the local artifact cache.  If configuration.cacheFolder is empty, the
+% Gradle default is used ('~/.gradle').
+%
+% The given remotePath should be a string artifact path, like those
+% returned from rdtListRemotePaths().  remotePath may be a partial or
+% "super" path, which matches multiple subpaths.
+%
+% Returns a cell array that contains the matching paths that were actually
+% deleted. Also returns a cell array indicating matching paths that were
+% not deleted, if any.
+%
+% See also rdtDeleteArtifacts rdtDeleteLocalpaths
+%
+% [deleted, notDeleted] = rdtDeleteRemotePaths(configuration, remotePath)
+%
+% Copyright (c) 2015 RemoteDataToolbox Team
+
+parser = rdtInputParser();
+parser.addRequired('configuration');
+parser.addRequired('remotePath', @ischar);
+parser.parse(configuration, remotePath);
+configuration = rdtConfiguration(parser.Results.configuration);
+remotePath = parser.Results.remotePath;
+
+%% Implementation note:
+% This delete operation is implemented in an Archiva-specific way.  So from
+% an implementation point of view, I would like to put this function in the
+% api/queries folder along with other functions that use the Archiva
+% RESTful API.
+%
+% But from a user point of view, it seems right to put this function here
+% in api/artifacts along with other functions related to the artifact
+% lifecycle.
+
+%% Make an explicit list of sub-paths that will be deleted.
+allPaths = rdtListRemotePaths(configuration);
+filterMe = struct('remotePath', allPaths);
+[~, matchingPaths] = rdtFilterStructArray(filterMe, 'remotePath', remotePath);
+remotePaths = {matchingPaths.remotePath};
+
+%% Remotely delete each sub-path one at a time.
+nPaths = numel(remotePaths);
+isDeleted = false(1, nPaths);
+for ii = 1:nPaths
+    % try to delete remotely
+    isDeleted(ii) = archivaDeleteRemotePath(configuration, remotePaths{ii});
+end
+
+deleted = remotePaths(isDeleted);
+notDeleted = remotePaths(~isDeleted);
+
+%% Clean up the local cache.
+rdtDeleteLocalPaths(configuration, remotePath);
+
+% Ask Archiva to delete a remote path.
+function isDeleted = archivaDeleteRemotePath(configuration, remotePath)
+configuration.acceptMediaType = 'text/plain';
+resourcePath = '/restServices/archivaServices/repositoriesService/deleteGroupId';
+groupId = rdtPathSlashesToDots(remotePath);
+deleteParams = struct( ...
+    'repositoryId', configuration.repositoryName, ...
+    'groupId', groupId);
+
+try
+    message = rdtRequestWeb(configuration, resourcePath, 'queryParams', deleteParams);
+    isDeleted = strcmpi('true', message);
+catch ex
+    isDeleted = false;
+    message = ex.message;
+end
+
+if ~isDeleted
+    fprintf('Could not delete remote path <%s>:\n%s\n', remotePath, message);
+    fprintf('Does your configuration have good credentials?\n');
+end

--- a/api/artifacts/rdtDeleteRemotePaths.m
+++ b/api/artifacts/rdtDeleteRemotePaths.m
@@ -1,24 +1,31 @@
 function [deleted, notDeleted] = rdtDeleteRemotePaths(configuration, remotePath)
-%% Delete paths with artifacts from a remote server and the local cache.
+%% Delete paths containing artifacts from a remote server and the local cache.
 %
-% [deleted, notDeleted] = rdtDeleteRemotePaths(configuration, remotePath)
-% deletes one or more paths containing artifacts from a remote servre and
-% the the local artifact cache. configuration.repositoryUrl must point to
-% the repository root.  configuration.cacheFolder should point to the root
-% of the local artifact cache.  If configuration.cacheFolder is empty, the
-% Gradle default is used ('~/.gradle').
+%   [deleted, notDeleted] = rdtDeleteRemotePaths(configuration, remotePath)
+% 
+% Deletes one or more paths containing artifacts from a remote server and
+% also from the local artifact cache. Thus, the local cache will not return
+% the artifacts after this delete is executed on the remote server.
 %
-% The given remotePath should be a string artifact path, like those
-% returned from rdtListRemotePaths().  remotePath may be a partial or
-% "super" path, which matches multiple subpaths.
+% Inputs:
+% remotePath - string to the remote path.  
+%   Should be a string artifact path, like those returned from
+%   rdtListRemotePaths(). The remotePath may be a partial or "super" path,
+%   which matches multiple subpaths.
+% configuration.repositoryUrl - must point to the repository root.  
+% configuration.cacheFolder   - should point to the root of the local
+%   artifact cache.  If configuration.cacheFolder is empty, the Gradle
+%   default is used ('~/.gradle'). 
 %
-% Returns a cell array that contains the matching paths that were actually
-% deleted. Also returns a cell array indicating matching paths that were
-% not deleted, if any.
+% Returns:
+%  deleted    - a cell array that contains the matching paths that were
+%               actually deleted. 
+%  notDeleted - a cell array indicating matching paths that were not
+%               deleted, if any. 
 %
 % See also rdtDeleteArtifacts rdtDeleteLocalpaths
 %
-% [deleted, notDeleted] = rdtDeleteRemotePaths(configuration, remotePath)
+% Examples:
 %
 % Copyright (c) 2015 RemoteDataToolbox Team
 
@@ -30,6 +37,7 @@ configuration = rdtConfiguration(parser.Results.configuration);
 remotePath = parser.Results.remotePath;
 
 %% Implementation note:
+%
 % This delete operation is implemented in an Archiva-specific way.  So from
 % an implementation point of view, I would like to put this function in the
 % api/queries folder along with other functions that use the Archiva

--- a/api/artifacts/rdtPublishArtifact.m
+++ b/api/artifacts/rdtPublishArtifact.m
@@ -19,6 +19,10 @@ function artifact = rdtPublishArtifact(configuration, file, remotePath, varargin
 % artifact = rdtPublishArtifact( ... 'name', name) adds the given
 % name to the artifact metadata.  The default is no name.
 %
+% artifact = rdtPublishArtifact( ... 'deleteLocal', deleteLocal) choose
+% whether to delete the artifact from the local cache after publishing.
+% The default is false, leave the artifact in the local cache.
+%
 % Returns a struct of metadata about the published artifact, or [] if the
 % publication failed.
 %
@@ -36,6 +40,7 @@ parser.addParameter('artifactId', '', @ischar);
 parser.addParameter('version', '1', @ischar);
 parser.addParameter('description', '', @ischar);
 parser.addParameter('name', '', @ischar);
+parser.addParameter('deleteLocal', false, @islogical);
 parser.parse(configuration, file, remotePath, varargin{:});
 configuration = rdtConfiguration(parser.Results.configuration);
 file = parser.Results.file;
@@ -44,6 +49,7 @@ artifactId = parser.Results.artifactId;
 version = parser.Results.version;
 description = parser.Results.description;
 name = parser.Results.name;
+deleteLocal = parser.Results.deleteLocal;
 
 if isempty(artifactId)
     [~, artifactId] = fileparts(file);
@@ -91,3 +97,9 @@ artifact = rdtArtifact( ...
     'url', remoteUrl, ...
     'description', description, ...
     'name', name);
+
+%% Optionally clean up the local cache.
+if deleteLocal
+    rdtDeleteLocalArtifacts(configuration, artifact);
+    artifact.localPath = '';
+end

--- a/api/artifacts/rdtPublishArtifacts.m
+++ b/api/artifacts/rdtPublishArtifacts.m
@@ -22,6 +22,10 @@ function artifacts = rdtPublishArtifacts(configuration, folder, remotePath, vara
 % artifact = rdtPublishArtifacts(... 'type', type) restricts publication to
 % only files that have the same file extension as the given type.
 %
+% artifact = rdtPublishArtifacts( ... 'deleteLocal', deleteLocal) choose
+% whether to delete the artifacts from the local cache after publishing.
+% The default is false, leave the artifacts in the local cache.
+%
 % Returns a struct array of metadata about the published artifacts, or []
 % if the publication failed.
 %
@@ -39,6 +43,7 @@ parser.addParameter('version', '1', @ischar);
 parser.addParameter('type', '', @ischar);
 parser.addParameter('description', '', @ischar);
 parser.addParameter('name', '', @ischar);
+parser.addParameter('deleteLocal', false, @islogical);
 parser.parse(configuration, folder, remotePath, varargin{:});
 configuration = rdtConfiguration(parser.Results.configuration);
 folder = parser.Results.folder;
@@ -47,6 +52,7 @@ version = parser.Results.version;
 type = parser.Results.type;
 description = parser.Results.description;
 name = parser.Results.name;
+deleteLocal = parser.Results.deleteLocal;
 
 artifacts = [];
 
@@ -61,7 +67,7 @@ for ii = 1:nFiles
         continue;
     end
     
-    [filePath, fileBase, fileExt] = fileparts(listing.name);
+    [~, fileBase, fileExt] = fileparts(listing.name);
     fileType = fileExt(fileExt ~= '.');
     
     isChosen(ii) = '.' ~= fileBase(1) ...
@@ -81,14 +87,15 @@ nArtifacts = numel(chosenListing);
 artifactCell = cell(1, nArtifacts);
 for ii = 1:nArtifacts
     file = fullfile(folder, chosenListing(ii).name);
-    [filePath, artifactId] = fileparts(file);
+    [~, artifactId] = fileparts(file);
     artifactCell{ii} = rdtPublishArtifact(configuration, ...
         file, ...
         remotePath, ...
         'artifactId', artifactId, ...
         'version', version, ...
         'description', description, ...
-        'name', name);
+        'name', name, ...
+        'deleteLocal', deleteLocal);
 end
 
 artifacts = [artifactCell{:}];

--- a/api/queries/rdtListLocalArtifacts.m
+++ b/api/queries/rdtListLocalArtifacts.m
@@ -64,42 +64,16 @@ artifacts = [];
 % want to collect a whole super-group like "validation.fast" we have to
 % find all the flattened groups by prefix matching.
 
-%% Locate the local artifact cache.
-cacheFolder = configuration.cacheFolder;
-if isempty(cacheFolder)
-    cacheFolder = '~/.gradle';
-end
+%% Locate mathcing paths in the cache.
+[localPaths, fullPaths] = rdtListLocalPaths(configuration, ...
+    'remotePath', remotePath);
 
-% magic subfolder used by Gradle, which we expect not to change
-GRADLE_CACHES_SUBFOLDER = '/caches/modules-2/files-2.1';
-cachePath = fullfile(cacheFolder, GRADLE_CACHES_SUBFOLDER);
-
-if 7 ~= exist(cachePath, 'dir')
-    warning('rdtListLocalArtifacts:cacheFolderMissing', ...
-        'No cache folder exists at <%s>.', cacheFolder);
-    return;
-end
-
-%% Locate the remotePaths at or below this group.
-superGroupId = rdtPathSlashesToDots(remotePath);
-cacheDirectories = dir(cachePath);
-[~, groupDirectories] = rdtFilterStructArray(cacheDirectories, ...
-    'name', superGroupId, ...
-    'matchStyle', 'prefix');
-
-if isempty(groupDirectories)
-    warning('rdtListLocalArtifacts:remotePathMissing', ...
-        'No cache entries for remotePath <%s>.', remotePath);
-    return;
-end
-
-%% Locate artifacts, versions, and files in each group.
+%% Locate artifacts, versions, and files under each local path.
 % it's deep, but constant depth, so let's do it!
 artifactCell = {};
-for gg = 1:numel(groupDirectories)
-    groupId = groupDirectories(gg).name;
-    artifactRemotePath = rdtPathDotsToSlashes(groupId);
-    groupPath = fullfile(cachePath, groupId);
+for pp = 1:numel(localPaths)
+    artifactRemotePath = localPaths{pp};
+    groupPath = fullPaths{pp};
     artifactDirectories = getMatchingEntries(dir(groupPath), artifactId);
     for aa = 1:numel(artifactDirectories)
         localArtifactId = artifactDirectories(aa).name;

--- a/api/queries/rdtListLocalPaths.m
+++ b/api/queries/rdtListLocalPaths.m
@@ -1,0 +1,101 @@
+function [localPaths, fullPaths] = rdtListLocalPaths(configuration, varargin)
+%% Query locally cached artifact paths.
+%
+% artifacts = rdtListLocalPaths(configuration) builds a list of paths
+% containing locally cached artifacts.  configuration.cacheFolder should
+% point to the root of the local artifact cache.  If
+% configuration.cacheFolder is empty, the Gradle default is used
+% ('~/.gradle').
+%
+% rdtListLocalPaths(... 'remotePath', remotePath) restricts the results to
+% local paths that correspond to the given remotePath.  remotePath may be a
+% partial or "super" path, which matches multiple subpaths.
+%
+% rdtListLocalPaths(... 'sortFlag', sortFlag) determines whether the
+% list of paths will be sorted.  The default is true, sorted.
+%
+% Returns a cell array of string paths found in the local cache, or {} if
+% the search failed.  These are formatted like artifact remotePaths.  Also
+% returns a cell array of full, absolute paths into the local artifact
+% cache.  These are formatted as full paths.
+%
+% See also rdtListRemotePaths, rdtListLocalArtifacts
+%
+% [localPaths, groupDirectories] = rdtListLocalPaths(configuration, varargin)
+%
+% Copyright (c) 2016 RemoteDataToolbox Team
+
+parser = rdtInputParser();
+parser.addRequired('configuration');
+parser.addParameter('remotePath', '', @ischar);
+parser.addParameter('sortFlag', true, @islogical);
+parser.parse(configuration, varargin{:});
+configuration = rdtConfiguration(parser.Results.configuration);
+remotePath = parser.Results.remotePath;
+sortFlag = parser.Results.sortFlag;
+
+localPaths = {};
+fullPaths = {};
+
+%% Implementaiton note.
+% The Gradle cache is nicely organized but slightly fussy to traverse.
+% Here is an example entry from isetbio:
+%   (cachePath)/validation.fast.outersegment/osBioPhysObject/run00001/4128b5adc8d39b7c42fa2eb9c5fa147c7aa38ca8/osBioPhysObject-run00001.pom
+% We can interpret this as:
+%   (cachePath)/groupId/artifactId/version/(checksum)/(file-name).type
+% Note that the groupId is a flattened version of the remotePath.  So
+%   (cachePath)/validation.fast.outersegment
+% and
+%   (cachePath)/validation.fast.colors
+% are *peers at the root level*.  They are not siblings nested under their
+% common super-group, which would be "validation.fast".  Flat groupIds are
+% great, because the keep the cache file tree at constant depth and we
+% don't have to do recursive traversal to arbitrary depths.  But, when we
+% want to collect a whole super-group like "validation.fast" we have to
+% find all the flattened groups by prefix matching.
+
+%% Locate the local artifact cache.
+cacheFolder = configuration.cacheFolder;
+if isempty(cacheFolder)
+    cacheFolder = '~/.gradle';
+end
+
+% magic subfolder used by Gradle, which we expect not to change
+GRADLE_CACHES_SUBFOLDER = '/caches/modules-2/files-2.1';
+cachePath = fullfile(cacheFolder, GRADLE_CACHES_SUBFOLDER);
+
+if 7 ~= exist(cachePath, 'dir')
+    warning('rdtListLocalPaths:cacheFolderMissing', ...
+        'No cache folder exists at <%s>.', cacheFolder);
+    return;
+end
+
+%% Locate the remotePaths at or below the given remotePath.
+superGroupId = rdtPathSlashesToDots(remotePath);
+cacheDirectories = dir(cachePath);
+[~, groupDirectories] = rdtFilterStructArray(cacheDirectories, ...
+    'name', superGroupId, ...
+    'matchStyle', 'prefix');
+
+if isempty(groupDirectories)
+    warning('rdtListLocalPaths:remotePathMissing', ...
+        'No cache entries for remotePath <%s>.', remotePath);
+    return;
+end
+
+%% Pack up the results.
+% convert group names with dots to paths with slashes
+nGroups = numel(groupDirectories);
+localPaths = cell(1, nGroups);
+fullPaths = cell(1, nGroups);
+for gg = 1:nGroups
+    groupId = groupDirectories(gg).name;
+    localPaths{gg} = rdtPathDotsToSlashes(groupId);
+    fullPaths{gg} = fullfile(cachePath, groupId);
+end
+
+% optional sort
+if sortFlag
+    [localPaths, order] = sort(localPaths);
+    fullPaths = fullPaths(order);
+end

--- a/api/queries/rdtListRemotePaths.m
+++ b/api/queries/rdtListRemotePaths.m
@@ -10,9 +10,9 @@ function [remotePaths, repositoryName] = rdtListRemotePaths(configuration, varar
 % rdtListRemotePaths(... 'sortFlag', sortFlag) determines whether the
 % list of remote paths will be sorted.  The default is true, sorted.
 %
-% Returns a cell array string paths returned from the Archiva respository,
-% or {} if the query failed.  Also returns the name of the repository whose
-% paths are listed.
+% Returns a cell array of string paths returned from the Archiva
+% respository, or {} if the query failed.  Also returns the name of the
+% repository whose paths are listed.
 %
 % See also rdtListArtifacts, rdtSearchArtifacts
 %

--- a/api/utilities/RdtClient.m
+++ b/api/utilities/RdtClient.m
@@ -254,10 +254,7 @@ classdef RdtClient < handle
                 % If there is no argument, then we open the repository URL,
                 % appending the working directory.
                 % open pwrp()
-                repoParts = rdtPathParts(obj.configuration.repositoryUrl);
-                remotePathParts = rdtPathParts(obj.workingRemotePath);
-                pathParts = cat(2, repoParts, remotePathParts);
-                url = rdtFullPath(pathParts, 'hasProtocol', true);
+                url = rdtBuildArtifactUrl(obj.configuration.repositoryUrl, obj.workingRemotePath, '', '');
                 
                 % Tell the open browser that we are sending in a full URL
                 rdtOpenBrowser(struct('url', url), 'url');

--- a/api/utilities/rdtFullPath.m
+++ b/api/utilities/rdtFullPath.m
@@ -9,7 +9,7 @@ function fullPath = rdtFullPath(pathParts, varargin)
 % For example, rdtFullPath({'', 'foo', 'bar'}) would build up to the
 % path "/foo/bar".
 %
-% converted = rdtConvertPathStyle(... 'separator', separator) uses the
+% converted = rdtFullPath(... 'separator', separator) uses the
 % given separator character instead of the default '/'.
 %
 % fullPath = rdtFullPath( ... 'trimLeading', trimLeading) obeys the

--- a/api/utilities/rdtSortStructArray.m
+++ b/api/utilities/rdtSortStructArray.m
@@ -15,7 +15,7 @@ function [sorted, order] = rdtSortStructArray(structArray, fieldName)
 % Copyright (c) 2016 RemoteDataToolbox Team
 
 parser = rdtInputParser();
-parser.addRequired('structArray', @isstruct);
+parser.addRequired('structArray', @(s) isempty(s) || isstruct(s));
 parser.addRequired('fieldName', @ischar);
 parser.parse(structArray, fieldName);
 structArray = parser.Results.structArray;
@@ -25,7 +25,11 @@ nElements = numel(structArray);
 sorted = structArray;
 order = 1:nElements;
 
-%% Sanity check the fieldName.
+%% Sanity check.
+if isempty(structArray)
+    return;
+end
+
 if ~isfield(structArray, fieldName)
     return;
 end

--- a/examples/brainard-archiva/rdtExampleDeleteData.m
+++ b/examples/brainard-archiva/rdtExampleDeleteData.m
@@ -1,0 +1,113 @@
+%% This is a tutorial for the Remote Data Toolbox object-oriented API.
+%
+% This script shows how to delete data with the Remote Data Toolbox.
+% Data artifacts can be deleted individually, or as groups.  Once deleted,
+% artifacts are no longer available to read from the remote server or from
+% the local artifact cache.
+%
+% This script uses a JSON file to configure a Remote Data Toolbox client
+% object with things like the Url of the project's remote repository.  This
+% simplifies various calls to the Remote Data Toolbox functions.
+%
+% You probably don't want to store your project's repository credentials in
+% a JSON file, because others would be able to read it.  So before
+% publishing data, this script will prompt you to enter a password into a
+% dialog window.  For this demo, use the user name "test" and password
+% "test123".
+%
+% See also rdtExampleReadData, rdtExamplePublishData
+%
+% Copyright (c) 2016 RemoteDataToolbox Team
+
+clear;
+clc;
+
+%% Create a client object with project configuration and credentials.
+client = RdtClient('brainard-archiva');
+client.credentialsDialog();
+
+%% Create 4 new artifacts and publish them.
+% For this example, the artifacts are mat-files that contain string hobbit
+% names.
+pathName = 'hobbits';
+hobbits = {'frodo', 'sam', 'merry', 'pippin'};
+
+% create a temp folder to work in
+tempFolder = fullfile(tempdir(), pathName);
+if 7 ~= exist(tempFolder, 'dir')
+    mkdir(tempFolder);
+end
+
+% save a temp mat file for each hobbit
+nArtifacts = numel(hobbits);
+tempFiles = cell(1, nArtifacts);
+for ii = 1:nArtifacts
+    name = hobbits{ii};
+    tempFiles{ii} = fullfile(tempFolder, [name '.mat']);
+    save(tempFiles{ii}, 'name');
+end
+
+% publish all the hobbits
+client.crp(pathName);
+published = client.publishArtifacts(tempFolder);
+
+% these hobbits were published
+fprintf('The following hobbits were published:\n');
+for ii = 1:numel(published);
+    fprintf('  %s\n', published(ii).artifactId);
+end
+
+%% Visit the hobbits on the web.
+% You should see 4 names listed.
+client.openBrowser();
+
+%% Delete one or two hobbits.
+% To delete specific artifacts, use elements of an artifact struct array,
+% like the struct array returned from publishArtifacts().
+victims = published([1,3]);
+
+% Delete uses a plain-old-function.  BSH is not sure if this belongs in the
+% RdtClient class because delete seems like a special case.
+deleted = rdtDeleteArtifacts(client.configuration, victims);
+
+% these ones were deleted!
+fprintf('The following hobbits were deleted:\n');
+for ii = 1:numel(deleted);
+    fprintf('  %s\n', deleted(ii).artifactId);
+end
+
+%% Delete all the remaining hobbits.
+% To delete many artifacts at once, use a remotePath that contains the
+% artifacts.
+victims = pathName;
+deleted = rdtDeleteRemotePaths(client.configuration, victims);
+
+% all of these were deleted!
+fprintf('The following paths aka folders aka groups were deleted:\n');
+for ii = 1:numel(deleted);
+    fprintf('  %s\n', deleted{ii});
+end
+
+%% Check the web again.
+% There should be no hobbits there!  You should see a 404 error or similar.
+client.openBrowser();
+
+%% Make sure we really can't read any of these hobbits.
+% rdtDeleteArtifacts() and rdtDeleteRemotePaths() delete things remotely
+% and also delete them from the local artifact cache.  This is important!
+% If we didn't clean up locally, we would still be able to read the
+% artifacts after they were deleted.  Let's verify that we can't read them.
+
+% should fail to read artifacts
+try
+    [datas, artifacts] = client.readArtifacts(published);
+    fprintf('For some reason we were able to read the deleted artifacts.\n');
+    fprintf('This is not what we expected.\n');
+catch ex
+    fprintf('It looks like we could not read the deleted artifacts.\n');
+    fprintf('That''s what we want!  The server said:\n%s\n', ex.message);
+    datas = {};
+    artifacts = {};
+end
+disp(datas)
+disp(artifacts)

--- a/test/RdtDeleteTests.m
+++ b/test/RdtDeleteTests.m
@@ -34,6 +34,29 @@ classdef RdtDeleteTests < matlab.unittest.TestCase
     end
     
     methods (Test)
+        function testDeletePathLocally(testCase)
+            published = testCase.publishTestArtifact();
+            
+            % should find local path for published artifact
+            [localPath, fullPath] = rdtListLocalPaths(testCase.testConfig, ...
+                'remotePath', published.remotePath);
+            testCase.assertNotEmpty(localPath);
+            testCase.assertNotEmpty(fullPath);
+            testCase.assertEqual(localPath{1}, published.remotePath);
+            testCase.assertEqual(exist(fullPath{1}, 'dir'), 7);
+            
+            [deleted, notDeleted] = rdtDeleteLocalPaths(testCase.testConfig, published.remotePath);
+            testCase.assertNotEmpty(deleted);
+            testCase.assertEqual(deleted{1}, published.remotePath);
+            testCase.assertEmpty(notDeleted);
+            
+            % should no longer find local path
+            [localPath, fullPath] = rdtListLocalPaths(testCase.testConfig, ...
+                'remotePath', published.remotePath);
+            testCase.assertEmpty(localPath);
+            testCase.assertEmpty(fullPath);
+        end
+        
         function testDeleteAsListedLocally(testCase)
             published = testCase.publishTestArtifact();
             foundLocally = rdtListLocalArtifacts(testCase.testConfig, ...

--- a/test/RdtDeleteTests.m
+++ b/test/RdtDeleteTests.m
@@ -1,0 +1,129 @@
+classdef RdtDeleteTests < matlab.unittest.TestCase
+    % Test that we can find and delete locally cached artifacts.
+    % These tests attempt to connect to our public Archiva server called
+    % brainard-archiva, using expected test credentials and repository
+    % contents. If the expected server can't be found, skips these tests.
+    
+    properties (Access = private)
+        testConfig = rdtConfiguration( ...
+            'serverUrl', 'http://52.32.77.154', ...
+            'repositoryUrl', 'http://52.32.77.154/repository/test-repository', ...
+            'repositoryName', 'test-repository', ...
+            'username', 'test', ...
+            'password', 'test123', ...
+            'requestMediaType', 'application/json', ...
+            'acceptMediaType', 'application/json', ...
+            'verbosity', 1);
+        
+        testArtifactFile = fullfile(tempdir(), 'temp-artifact.mat');
+    end
+    
+    methods (TestMethodSetup)
+        function checkIfServerPresent(testCase)
+            [isConnected, message] = rdtPingServer(testCase.testConfig);
+            testCase.assumeTrue(isConnected, message);
+        end
+    end
+    
+    methods (TestMethodTeardown)
+        function deleteTestArtifact(testCase)
+            if exist(testCase.testArtifactFile, 'file')
+                delete(testCase.testArtifactFile);
+            end
+        end
+    end
+    
+    methods (Test)
+        function testDeleteAsListed(testCase)
+            published = testCase.publishTestArtifact();
+            foundLocally = rdtListLocalArtifacts(testCase.testConfig, ...
+                published.remotePath, ...
+                'artifactId', published.artifactId);
+            
+            testCase.assertNotEmpty(foundLocally);
+            testCase.assertInstanceOf(foundLocally, 'struct');
+            testCase.assertTrue(all(strcmp(published.artifactId, {foundLocally.artifactId})));
+            
+            [deleted, notDeleted] = rdtDeleteLocalArtifacts(testCase.testConfig, ...
+                foundLocally);
+            
+            testCase.assertNotEmpty(deleted);
+            testCase.assertInstanceOf(deleted, 'struct');
+            testCase.assertEqual(sort({deleted.artifactId}), sort({foundLocally.artifactId}));
+            
+            testCase.assertEmpty(notDeleted);
+        end
+        
+        function testDeleteAsPublished(testCase)
+            published = testCase.publishTestArtifact();
+            [deleted, notDeleted] = rdtDeleteLocalArtifacts(testCase.testConfig, ...
+                published);
+            
+            testCase.assertNotEmpty(deleted);
+            testCase.assertInstanceOf(deleted, 'struct');
+            testCase.assertTrue(all(strcmp(published.artifactId, {deleted.artifactId})));
+            
+            testCase.assertEmpty(notDeleted);
+        end
+        
+        function testBogusNotDeleted(testCase)
+            bogus = rdtArtifact( ...
+                'artifactId', 'bogus-artifact', ...
+                'localPath', 'nonononotapath');
+            [deleted, notDeleted] = rdtDeleteLocalArtifacts(testCase.testConfig, ...
+                bogus);
+            
+            testCase.assertEmpty(deleted);
+            
+            testCase.assertNotEmpty(notDeleted);
+            testCase.assertInstanceOf(notDeleted, 'struct');
+            testCase.assertEqual(notDeleted.artifactId, bogus.artifactId);
+        end
+        
+        function testSomeRealSomeBogus(testCase)
+            published = testCase.publishTestArtifact();
+            foundLocally = rdtListLocalArtifacts(testCase.testConfig, ...
+                published.remotePath, ...
+                'artifactId', published.artifactId);
+            
+            boguses(1) = rdtArtifact( ...
+                'artifactId', 'bogus-artifact-1', ...
+                'localPath', 'nonononotapath');
+            boguses(2) = rdtArtifact( ...
+                'artifactId', 'bogus-artifact-2', ...
+                'localPath', 'thisisiaboguspath');
+            [deleted, notDeleted] = rdtDeleteLocalArtifacts(testCase.testConfig, ...
+                [foundLocally, boguses]);
+            
+            testCase.assertNotEmpty(deleted);
+            testCase.assertInstanceOf(deleted, 'struct');
+            testCase.assertEqual(sort({deleted.artifactId}), sort({foundLocally.artifactId}));
+            
+            testCase.assertNotEmpty(notDeleted);
+            testCase.assertInstanceOf(notDeleted, 'struct');
+            testCase.assertEqual(sort({notDeleted.artifactId}), sort({boguses.artifactId}));
+        end
+        
+    end
+    
+    methods
+        function [artifact, testArtifactData] = publishTestArtifact(testCase)
+            % Actually publishing something seems like the best way to get
+            % something in the local cache that we are free to delete.
+            % This avoids interaction with other tests and also avoids
+            % unintended side effects of finding some other way to populate
+            % the cache.
+            
+            testArtifactData = 'please delete me!';
+            save(testCase.testArtifactFile, 'testArtifactData');
+            
+            artifact = rdtPublishArtifact(testCase.testConfig, ...
+                testCase.testArtifactFile, ...
+                'delete-me', ...
+                'artifactId', 'delete-me', ...
+                'version', '0', ...
+                'name', 'Dr. Delete', ...
+                'description', 'Please delete this temporary test artifact.');
+        end
+    end
+end

--- a/test/RdtDeleteTests.m
+++ b/test/RdtDeleteTests.m
@@ -57,6 +57,39 @@ classdef RdtDeleteTests < matlab.unittest.TestCase
             testCase.assertEmpty(fullPath);
         end
         
+        function testDeletePathRemotely(testCase)
+            published = testCase.publishTestArtifact();
+            
+            % should find local path for published artifact
+            [localPath, fullPath] = rdtListLocalPaths(testCase.testConfig, ...
+                'remotePath', published.remotePath);
+            testCase.assertNotEmpty(localPath);
+            testCase.assertNotEmpty(fullPath);
+            testCase.assertEqual(localPath{1}, published.remotePath);
+            testCase.assertEqual(exist(fullPath{1}, 'dir'), 7);
+            
+            [deleted, notDeleted] = rdtDeleteRemotePaths(testCase.testConfig, published.remotePath);
+            testCase.assertNotEmpty(deleted);
+            testCase.assertEqual(deleted{1}, published.remotePath);
+            testCase.assertEmpty(notDeleted);
+            
+            % should no longer find local path
+            [localPath, fullPath] = rdtListLocalPaths(testCase.testConfig, ...
+                'remotePath', published.remotePath);
+            testCase.assertEmpty(localPath);
+            testCase.assertEmpty(fullPath);
+            
+            % should no longer be able to read remote artifact
+            try
+                [data, artifact] = rdtReadArtifacts(testCase.testConfig, published);
+            catch
+                data = {};
+                artifact = {};
+            end
+            testCase.assertEmpty(data);
+            testCase.assertEmpty(artifact);
+        end
+        
         function testDeleteAsListedLocally(testCase)
             published = testCase.publishTestArtifact();
             foundLocally = rdtListLocalArtifacts(testCase.testConfig, ...

--- a/test/RdtPublishTests.m
+++ b/test/RdtPublishTests.m
@@ -96,7 +96,7 @@ classdef RdtPublishTests < matlab.unittest.TestCase
                 'publish-multiple-group', ...
                 'version', '123');
             testCase.assertNumElements(listed, numel(artifacts));
-
+            
             % make sure we can find these
             found = rdtSearchArtifacts(testCase.testConfig, ...
                 'publish-multiple-group', ...
@@ -125,6 +125,32 @@ classdef RdtPublishTests < matlab.unittest.TestCase
             artifactIds = {artifacts.artifactId};
             testCase.assertTrue(any(strcmp('text-artifact', artifactIds)));
             testCase.assertTrue(any(strcmp('multiple-flavor-test', artifactIds)));
+        end
+        
+        function testPublishMultipleDeleteLocal(testCase)
+            % publish the testArtifacts from this folder
+            thisFolder = fileparts(mfilename('fullpath'));
+            artifactFolder = fullfile(thisFolder, 'testArtifacts');
+            
+            artifacts = rdtPublishArtifacts(testCase.testConfig, ...
+                artifactFolder, ...
+                'publish-multiple-group', ...
+                'version', '890', ...
+                'name', 'Test', ...
+                'description', 'This is one of several tests.', ...
+                'deleteLocal', true);
+            
+            testCase.assertNotEmpty(artifacts);
+            testCase.assertInstanceOf(artifacts, 'struct');
+            
+            % make sure we don't see these artifacts in the local cache
+            for ii = 1:numel(artifacts)
+                foundLocally = rdtListLocalArtifacts(testCase.testConfig, ...
+                    artifacts(ii).remotePath, ...
+                    'version', artifacts(ii).version, ...
+                    'type', artifacts(ii).type);
+                testCase.assertEmpty(foundLocally);
+            end
         end
     end
 end


### PR DESCRIPTION
This branch deals with deleting artifacts.

There are several commits, but the basic idea is simple: we can delete remote artifacts or groups of artifacts using the Matlab client.  When we do this, we also clean up the local artifact cache.  This prevents us from being able to read an artifact after we deleted it locally.

Here is are the main additions:
- `rdtDeleteLocalArtifacts()` delete artifact files from the local cache
- `rdtDeleteLocalPaths()` delete whole folders from the local cache
- `rdtDeleteArtifacts()` delete artifact files remotely and locally
- `rdtDeleteRemotePaths()` delete whole folders remotely and locally
- `rdtPublishArtifact()` and `rdtPublishArtifacts()` have a new `deleteLocal` flag.  When set to true, artifacts will be deleted from the local cache just after they are published.
- tests for the functions above
- `rdtExampleDeleteData.m` is a new demo script for some of the functions above.
