### PR TITLE
Archiva rescan

### DIFF
--- a/api/artifacts/rdtPublishArtifact.m
+++ b/api/artifacts/rdtPublishArtifact.m
@@ -23,6 +23,10 @@ function artifact = rdtPublishArtifact(configuration, file, remotePath, varargin
 % whether to delete the artifact from the local cache after publishing.
 % The default is false, leave the artifact in the local cache.
 %
+% artifact = rdtPublishArtifact( ... 'rescan', rescan) choose
+% whether to request the remote repository to update its artifact listing
+% and search index.  The default is true -- rescan and update.
+%
 % Returns a struct of metadata about the published artifact, or [] if the
 % publication failed.
 %
@@ -41,6 +45,7 @@ parser.addParameter('version', '1', @ischar);
 parser.addParameter('description', '', @ischar);
 parser.addParameter('name', '', @ischar);
 parser.addParameter('deleteLocal', false, @islogical);
+parser.addParameter('rescan', true, @islogical);
 parser.parse(configuration, file, remotePath, varargin{:});
 configuration = rdtConfiguration(parser.Results.configuration);
 file = parser.Results.file;
@@ -50,6 +55,7 @@ version = parser.Results.version;
 description = parser.Results.description;
 name = parser.Results.name;
 deleteLocal = parser.Results.deleteLocal;
+rescan = parser.Results.rescan;
 
 if isempty(artifactId)
     [~, artifactId] = fileparts(file);
@@ -72,6 +78,11 @@ artifact = [];
 
 if isempty(localPath)
     return;
+end
+
+%% Ask the remote server to rescan the repository?
+if rescan
+    rdtRequestRescan(configuration);
 end
 
 %% Read more metadata from the artifact pom.

--- a/api/artifacts/rdtPublishArtifacts.m
+++ b/api/artifacts/rdtPublishArtifacts.m
@@ -26,6 +26,10 @@ function artifacts = rdtPublishArtifacts(configuration, folder, remotePath, vara
 % whether to delete the artifacts from the local cache after publishing.
 % The default is false, leave the artifacts in the local cache.
 %
+% artifact = rdtPublishArtifacts( ... 'rescan', rescan) choose
+% whether to request the remote repository to update its artifact listing
+% and search index.  The default is true -- rescan and update.
+%
 % Returns a struct array of metadata about the published artifacts, or []
 % if the publication failed.
 %
@@ -44,6 +48,7 @@ parser.addParameter('type', '', @ischar);
 parser.addParameter('description', '', @ischar);
 parser.addParameter('name', '', @ischar);
 parser.addParameter('deleteLocal', false, @islogical);
+parser.addParameter('rescan', true, @islogical);
 parser.parse(configuration, folder, remotePath, varargin{:});
 configuration = rdtConfiguration(parser.Results.configuration);
 folder = parser.Results.folder;
@@ -53,6 +58,7 @@ type = parser.Results.type;
 description = parser.Results.description;
 name = parser.Results.name;
 deleteLocal = parser.Results.deleteLocal;
+rescan = parser.Results.rescan;
 
 artifacts = [];
 
@@ -98,7 +104,14 @@ for ii = 1:nArtifacts
         'version', version, ...
         'description', description, ...
         'name', name, ...
-        'deleteLocal', deleteLocal);
+        'deleteLocal', deleteLocal, ...
+        'rescan', false);
 end
 
 artifacts = [artifactCell{:}];
+
+%% Ask the remote server to rescan the repository?
+if rescan
+    rdtRequestRescan(configuration);
+end
+

--- a/api/queries/rdtRequestRescan.m
+++ b/api/queries/rdtRequestRescan.m
@@ -1,0 +1,67 @@
+function [isScanning, message] = rdtRequestRescan(configuration, varargin)
+%% Request Archiva to re-scan a repository for artifact listings.
+%
+% [isScanning, message] = rdtRequestRescan(configuration) requests a
+% repository re-scan from an Archiva Maven repository.  If successful, this
+% will cause the repository artifact listing and search index to be
+% re-generated immediately.  This may be useful when modifying the
+% repository contents. configuration.serverUrl must point to the Archiva
+% server root.  configuration.repositoryName must contain the id of an
+% existing Archiva repository on the same server.
+%
+% Re-scanning an repository requires an Archiva user with the "run indexer"
+% permission.  This permission is separate from the usual permissions
+% required to read and write the repository contents.  As a result, this
+% command will only succeed if the give configuration contains credentials
+% for an Archiva system administrator.
+%
+% On success, this function will *initiate* the re-scan.  It may take some
+% time for the scan to be completed.  For small repositories, the time
+% required should be less than a second.  Still, there may be a "race
+% condition" between the completion of the re-scan and any listing or
+% searching requests you invoke after this function.
+%
+% rdtRequestRescan( ... 'delaySecs', delaySecs) pauses after requesting the
+% re-scan for the given number of delaySecs.  This may be a "cheap" way to
+% avoid race conditions at the expense of a small delay.  The default is 0,
+% don't delay at all.
+%
+% Returns a logical value, true only if the server responded with a success
+% message.  Also returns a string message from the server in case of
+% success or failure.
+%
+% [isScanning, message] = rdtRequestRescan(configuration, varargin)
+%
+% Copyright (c) 2015 RemoteDataToolbox Team
+
+parser = rdtInputParser();
+parser.addRequired('configuration');
+parser.addParameter('delaySecs', 0, @isnumeric);
+parser.parse(configuration, varargin{:});
+configuration = rdtConfiguration(parser.Results.configuration);
+delaySecs = parser.Results.delaySecs;
+
+isScanning = false;
+message = '';
+
+%% Request the re-scan.
+requestPath = '/restServices/archivaServices/repositoriesService/scanRepositoryNow';
+scanConfig = configuration;
+scanConfig.acceptMediaType = 'text/plain';
+queryParams = struct( ...
+    'repositoryId', scanConfig.repositoryName, ...
+    'fullScan', 1);
+
+try
+    message = rdtRequestWeb(scanConfig, requestPath, 'queryParams', queryParams);
+    isScanning = true;
+    
+    % wait for the re-scan to complete?
+    if delaySecs > 0
+        fprintf('%.1f second delay for repository rescan...', delaySecs);
+        pause(delaySecs);
+        fprintf('done!\n');
+    end
+catch ex
+    message = ex.message;
+end

--- a/api/queries/rdtRequestRescan.m
+++ b/api/queries/rdtRequestRescan.m
@@ -1,7 +1,7 @@
-function [isScanning, message] = rdtRequestRescan(configuration, varargin)
+function [isStarted, message] = rdtRequestRescan(configuration, varargin)
 %% Request Archiva to re-scan a repository for artifact listings.
 %
-% [isScanning, message] = rdtRequestRescan(configuration) requests a
+% [isStarted, message] = rdtRequestRescan(configuration) requests a
 % repository re-scan from an Archiva Maven repository.  If successful, this
 % will cause the repository artifact listing and search index to be
 % re-generated immediately.  This may be useful when modifying the
@@ -18,18 +18,18 @@ function [isScanning, message] = rdtRequestRescan(configuration, varargin)
 % On success, this function will *initiate* the re-scan.  It may take some
 % time for the scan to be completed.  For small repositories, the time
 % required should be less than a second.  Still, there may be a "race
-% condition" between the completion of the re-scan and any listing or
-% searching requests you invoke after this function.
+% condition" between the completion of the re-scan and any subsequent
+% requests for artifact listings or searches.
 %
 % rdtRequestRescan( ... 'timeout', timeout) waits after requesting the
 % re-scan until the given timeout in seconds has elapsed, or the Archiva
 % server reports that the scan is complete.
 %
 % Returns a logical value, true only if the server responded with a success
-% message.  Also returns a string message from the server in case of
-% success or failure.
+% message when asked to initiate the scan.  Also returns a string message
+% from the server in case of success or failure.
 %
-% [isScanning, message] = rdtRequestRescan(configuration, varargin)
+% [isStarted, message] = rdtRequestRescan(configuration, varargin)
 %
 % Copyright (c) 2015 RemoteDataToolbox Team
 
@@ -40,7 +40,7 @@ parser.parse(configuration, varargin{:});
 configuration = rdtConfiguration(parser.Results.configuration);
 timeout = parser.Results.timeout;
 
-isScanning = false;
+isStarted = false;
 message = '';
 
 %% Request the re-scan.
@@ -53,7 +53,7 @@ scanParams = struct( ...
 
 try
     message = rdtRequestWeb(scanConfig, scanPath, 'queryParams', scanParams);
-    isScanning = true;
+    isStarted = true;
     
     % wait for the re-scan to complete?
     if timeout > 0

--- a/api/utilities/RdtClient.m
+++ b/api/utilities/RdtClient.m
@@ -268,5 +268,16 @@ classdef RdtClient < handle
                 url = rdtOpenBrowser(obj.configuration, whichUrlOrArtifact);
             end
         end
+        
+        function [isScanning, message] = requestRescan(obj, varargin)
+            % Ask Archiva to rescan the repository to up-to-date artifact
+            % listing and searching.
+            %   [isScanning, message] = requestRescan() initiate scan
+            %   [isScanning, message] = requestRescan('delaySecs',
+            %       delaySecs) wait delaySecs for scan to finish.
+            
+            [isScanning, message] = rdtRequestRescan(obj.configuration, ...
+                varargin{:});
+        end
     end
 end

--- a/api/utilities/RdtClient.m
+++ b/api/utilities/RdtClient.m
@@ -269,14 +269,14 @@ classdef RdtClient < handle
             end
         end
         
-        function [isScanning, message] = requestRescan(obj, varargin)
+        function [isStarted, message] = requestRescan(obj, varargin)
             % Ask Archiva to rescan the repository to up-to-date artifact
             % listing and searching.
-            %   [isScanning, message] = requestRescan() initiate scan
-            %   [isScanning, message] = requestRescan('timeout',
+            %   [isStarted, message] = requestRescan() initiate scan
+            %   [isStarted, message] = requestRescan('timeout',
             %       timeout) wait up to timeout seconds for scan to finish.
             
-            [isScanning, message] = rdtRequestRescan(obj.configuration, ...
+            [isStarted, message] = rdtRequestRescan(obj.configuration, ...
                 varargin{:});
         end
     end

--- a/api/utilities/RdtClient.m
+++ b/api/utilities/RdtClient.m
@@ -273,8 +273,8 @@ classdef RdtClient < handle
             % Ask Archiva to rescan the repository to up-to-date artifact
             % listing and searching.
             %   [isScanning, message] = requestRescan() initiate scan
-            %   [isScanning, message] = requestRescan('delaySecs',
-            %       delaySecs) wait delaySecs for scan to finish.
+            %   [isScanning, message] = requestRescan('timeout',
+            %       timeout) wait up to timeout seconds for scan to finish.
             
             [isScanning, message] = rdtRequestRescan(obj.configuration, ...
                 varargin{:});

--- a/test/RdtRescanTests.m
+++ b/test/RdtRescanTests.m
@@ -1,0 +1,58 @@
+classdef RdtRescanTests < matlab.unittest.TestCase
+    % Test that we can trigger re-scans of Archiva repositories.
+    % These tests attempt to connect to our public Archiva server called
+    % brainard-archiva, using expected test credentials and repository
+    % contents. If the expected server can't be found, skips these tests.
+    
+    properties (Access = private)
+        testConfig = rdtConfiguration( ...
+            'serverUrl', 'http://52.32.77.154', ...
+            'repositoryUrl', 'http://52.32.77.154/repository/test-repository', ...
+            'repositoryName', 'test-repository', ...
+            'username', 'test', ...
+            'password', 'test123', ...
+            'requestMediaType', 'application/json', ...
+            'acceptMediaType', 'application/json', ...
+            'verbosity', 1);
+        
+        testArtifactFile = fullfile(tempdir(), 'temp-artifact.mat');
+    end
+    
+    methods (TestMethodSetup)
+        
+        function checkIfServerPresent(testCase)
+            [isConnected, message] = rdtPingServer(testCase.testConfig);
+            testCase.assumeTrue(isConnected, message);
+        end
+    end
+    
+    methods (TestMethodTeardown)
+        function deleteTestArtifact(testCase)
+            if exist(testCase.testArtifactFile, 'file')
+                delete(testCase.testArtifactFile);
+            end
+        end
+    end
+    
+    methods (Test)
+        
+        function testBadCredentials(testCase)
+            config = testCase.testConfig;
+            config.username = 'nonononotauser';
+            config.password = 'nonononodontsayfriendandenter';
+            isStarted = rdtRequestRescan(config);
+            testCase.assertFalse(isStarted);
+        end
+        
+        function testGoodCredentials(testCase)
+            isStarted = rdtRequestRescan(testCase.testConfig);
+            testCase.assertTrue(isStarted);
+        end
+        
+        function testTimeout(testCase)
+            isStarted = rdtRequestRescan(testCase.testConfig, ...
+                'timeout', 10);
+            testCase.assertTrue(isStarted);
+        end        
+    end
+end

--- a/test/RdtRescanTests.m
+++ b/test/RdtRescanTests.m
@@ -39,7 +39,7 @@ classdef RdtRescanTests < matlab.unittest.TestCase
         function testBadCredentials(testCase)
             config = testCase.testConfig;
             config.username = 'nonononotauser';
-            config.password = 'nonononodontsayfriendandenter';
+            config.password = 'nononononeithersayfriendnorenter';
             isStarted = rdtRequestRescan(config);
             testCase.assertFalse(isStarted);
         end
@@ -53,6 +53,78 @@ classdef RdtRescanTests < matlab.unittest.TestCase
             isStarted = rdtRequestRescan(testCase.testConfig, ...
                 'timeout', 10);
             testCase.assertTrue(isStarted);
-        end        
+        end
+        
+        function testModifyRepository(testCase)
+            % create a random test artifact
+            testArtifactData = rand(42, 43);
+            save(testCase.testArtifactFile, 'testArtifactData');
+            
+            % create a random artifact id to isolate this test
+            alphabet = 'a':'z';
+            artifactId = alphabet(randperm(numel(alphabet)));
+            remotePath = 'rescan-group';
+            
+            % publish the artifact
+            published = rdtPublishArtifact(testCase.testConfig, ...
+                testCase.testArtifactFile, ...
+                remotePath, ...
+                'artifactId', artifactId);
+            testCase.assertNotEmpty(published);
+            testCase.assertInstanceOf(published, 'struct');
+            testCase.assertEqual(published.artifactId, artifactId);
+            
+            % publish should have triggered a repository re-scan
+            %   so we should be able to list and search immediately
+            listed = rdtListArtifacts(testCase.testConfig, ...
+                remotePath, ...
+                'artifactId', artifactId);
+            testCase.assertNotEmpty(listed);
+            testCase.assertInstanceOf(listed, 'struct');
+            testCase.assertEqual(listed.artifactId, artifactId);
+            
+            found = rdtSearchArtifacts(testCase.testConfig, ...
+                artifactId, ...
+                'artifactId', artifactId, ...
+                'remotePath', remotePath);
+            testCase.assertNotEmpty(found);
+            testCase.assertInstanceOf(found, 'struct');
+            testCase.assertEqual(found.artifactId, artifactId);
+            
+            listedPaths = rdtListRemotePaths(testCase.testConfig);
+            testCase.assertNotEmpty(listedPaths);
+            testCase.assertTrue(any(strcmp(listedPaths, remotePath)));
+            
+            % delete the artifact
+            deleted = rdtDeleteArtifacts(testCase.testConfig, ...
+                published);
+            testCase.assertNotEmpty(deleted);
+            testCase.assertInstanceOf(deleted, 'struct');
+            testCase.assertEqual(deleted.artifactId, artifactId);
+            
+            % delete should have triggered a repository re-scan
+            %   so we should no longer be able to list and search
+            listedAgain = rdtListArtifacts(testCase.testConfig, ...
+                remotePath, ...
+                'artifactId', artifactId);
+            testCase.assertEmpty(listedAgain);
+            
+            foundAgain = rdtSearchArtifacts(testCase.testConfig, ...
+                artifactId, ...
+                'artifactId', artifactId, ...
+                'remotePath', remotePath);
+            testCase.assertEmpty(foundAgain);
+            
+            % delete the remote group
+            deleted = rdtDeleteRemotePaths(testCase.testConfig, remotePath);
+            testCase.assertNotEmpty(deleted);
+            testCase.assertTrue(any(strcmp(deleted, remotePath)));
+            
+            % delete should have triggered a repository re-scan
+            %   so we should no longer be able to list the path
+            listedPaths = rdtListRemotePaths(testCase.testConfig);
+            testCase.assertNotEmpty(listedPaths);
+            testCase.assertFalse(any(strcmp(listedPaths, remotePath)));
+        end
     end
 end

--- a/test/v_rdtSCIEN.m
+++ b/test/v_rdtSCIEN.m
@@ -25,12 +25,15 @@ a = rd.listArtifacts;
 disp('This artifact found')
 a.artifactId
 
-% Poke around
-rd.openBrowser;
+% BSH: let's look specifically at the image-artifact version 1 folder
+% it should contain the jpg and various metadata files
+artifactFolderHack = rdtArtifact('url', fileparts(a.url));
+rd.openBrowser(artifactFolderHack);
 
 %% Remove the file
 
-deleted = rdtDeleteArtifacts(rd.configuration, a);
+% BSH: try again with the new 'allFiles' flag
+deleted = rdtDeleteArtifacts(rd.configuration, a, 'allFiles', true);
 
 % This returns an empty artifact, which is good
 a = rd.listArtifacts;
@@ -38,18 +41,25 @@ if isempty(a)
     disp('Artifact successfully deleted')
 end
 
-% The pom file and related (md6, sha1, xml) are still there
+%BSH: The pom file and related (md6, sha1, xml) that we say above should
+%have been deleted.
 
 %% Now, test triggering a rescan
 
 % Ask for a rescan - not sure what this does ...
+
+% BSH: rdtDeleteArtifacts() already should have rescanned automatically.
+% And if listArtifacts() above returned empty, then the rescan was
+% successful.  So this rescan here is redundant but harmless.
+
 [isStarted,message] = rd.requestRescan;
 if isStarted
     disp('Rescan is initiated')
 end
 
-% Poke around.  In my case, I see a lot of files.
-rd.openBrowser;
+% now the whole artifact is gone!
+%   expect a 404 error
+rd.openBrowser(artifactFolderHack);
 
 %% But the artifact is invisible
 rd.crp('/');
@@ -61,5 +71,12 @@ end
 % Is that the expected behavior?  When do the pom, md5, and other files go
 % away?
 
-%%
+% BSH with the allFiles flag to rdtDeleteArtifacts(), we can make a whole
+% folder go away, including the pom, data files, and other metadata
+
+% BSH but there is still a mostly-empty folder that we might have to live
+% with
+
+% still see a folder named briefTest/image-artifact/  :(
+rd.openBrowser();
 

--- a/test/v_rdtSCIEN.m
+++ b/test/v_rdtSCIEN.m
@@ -1,0 +1,65 @@
+%% Test upload and delete from the archiva server for the pull request
+%
+% Main point is to ask Ben what I am doing wrong, or to figure out that
+% this is the expected behavior.  In either case, it works well enough that
+% I will do the merge.
+%
+% BW, ISETBIO Team
+
+%
+close all
+clear all
+
+%%
+rd = RdtClient('scien');
+rd.credentialsDialog;
+
+%% Upload a file to briefTest directory
+
+rd.crp('/briefTest');
+fullFile = fullfile(rdtRootPath,'test','testArtifacts','image-artifact.jpg');
+exist(fullFile,'file');
+rd.publishArtifact(fullFile,'type','jpg');
+
+a = rd.listArtifacts;
+disp('This artifact found')
+a.artifactId
+
+% Poke around
+rd.openBrowser;
+
+%% Remove the file
+
+deleted = rdtDeleteArtifacts(rd.configuration, a);
+
+% This returns an empty artifact, which is good
+a = rd.listArtifacts;
+if isempty(a)
+    disp('Artifact successfully deleted')
+end
+
+% The pom file and related (md6, sha1, xml) are still there
+
+%% Now, test triggering a rescan
+
+% Ask for a rescan - not sure what this does ...
+[isStarted,message] = rd.requestRescan;
+if isStarted
+    disp('Rescan is initiated')
+end
+
+% Poke around.  In my case, I see a lot of files.
+rd.openBrowser;
+
+%% But the artifact is invisible
+rd.crp('/');
+a = rd.listArtifacts('remotePath','briefTest');
+if isempty(a)
+    disp('No artifacts in the briefTest directory')
+end
+
+% Is that the expected behavior?  When do the pom, md5, and other files go
+% away?
+
+%%
+


### PR DESCRIPTION
This PR allows the Matlab client to trigger "re-scans" of remote Archiva repositories.

A re-scan causes Archiva to update the artifact listing and search index for a repository.  This is necessary when publishing or deleting artifacts, in order to maintain a consistent view of the world.  
Without client-triggered re-scans, you'd have to wait around for a periodic re-scan, or log in with a browser  and trigger a re-scan manually.

The new utility is called `rdtRequestRescan()`.  You can invoke this utility directly or through `RdtClient.requestRescan()`.  Also, it is integrated with publishing and deleting functions, so re-scans should happen automatically at appropriate times.

[Here is a test case](https://github.com/isetbio/RemoteDataToolbox/blob/archivaRescan/test/RdtRescanTests.m#L58) which makes a fair summary.  As you publish and delete artifacts, the list and search functions stay consistent with reality.
