### PR TITLE
Version check for inputParser PartialMatching field

### DIFF
--- a/api/utilities/rdtInputParser.m
+++ b/api/utilities/rdtInputParser.m
@@ -14,5 +14,10 @@ parser = inputParser();
 
 parser.CaseSensitive = true;
 parser.KeepUnmatched = true;
-parser.PartialMatching = false;
 parser.StructExpand = false;
+
+% PartialMatching is not an option in Matlab < ~8.2/R2013b
+%   That's OK.  We just want to turn it off when we have the choice.
+if ~verLessThan('matlab', '8.2')
+    parser.PartialMatching = false;
+end


### PR DESCRIPTION
We don't want inputParser to do prefix matching on parameter names (explicit is good).

Before Matlab version ~8.2/R2013b this was not even an option.  In later versions, when it is an option, we turn off this "PartialMatching".

This new version check should prevent errors on older versions of Matlab.
